### PR TITLE
set `CC?=cc`, and fix C warnings reported by clang

### DIFF
--- a/nolibc/Makefile
+++ b/nolibc/Makefile
@@ -5,7 +5,7 @@ ifeq ($(SYSDEP_OBJS),)
     $(error SYSDEP_OBJS not set)
 endif
 
-CC=gcc
+CC?=cc
 CFLAGS=-O2 -std=c99 -Wall -Wno-maybe-uninitialized -Wno-parentheses -Werror
 CFLAGS+=$(FREESTANDING_CFLAGS)
 

--- a/nolibc/sysdeps_solo5.c
+++ b/nolibc/sysdeps_solo5.c
@@ -83,13 +83,13 @@ int gettimeofday(struct timeval *tv, struct timezone *tz)
 	tv->tv_usec = (now % NSEC_PER_SEC) / 1000ULL;
     }
     if (tz != NULL) {
-	memset(tz, 0, sizeof tz);
+	memset(tz, 0, sizeof(*tz));
     }
     return 0;
 }
 
 clock_t times(struct tms *buf)
 {
-    memset(buf, 0, sizeof buf);
+    memset(buf, 0, sizeof(*buf));
     return (clock_t)solo5_clock_monotonic();
 }


### PR DESCRIPTION
this works fine with gcc as well